### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
 # List of topics covered in this repository
 
-- [How to set up and start to use Oracle Property Graph server](https://github.com/rexzj266/oracle-pgx-on-dbcs-quickstart/blob/master/manual-setup/pgx-manual-setup-dbcs.md)
-  - [English](https://github.com/rexzj266/oracle-pgx-on-dbcs-quickstart/blob/master/manual-setup/pgx-manual-setup-dbcs.md)
-  - 中文版
-  - [日本語](https://github.com/kumasan368/oracle-pgx-on-dbcs-quickstart1/blob/master/manual-setup/pgx-manual-setup-dbcs-jp.md)
+This tutorial show how to quickly deploy Graph Server using Marketplace image and integrate with Oracle Database running on DBCS (Database Cloud Service).
 
-- [Deploy Oracle Property Graph Server from Marketplace](https://github.com/rexzj266/oracle-pgx-on-dbcs-quickstart/blob/master/marketplace/pdx-deploy-from-marketplace.md)
+- [Deploy Graph Server with DBCS](https://github.com/rexzj266/oracle-pgx-on-dbcs-quickstart/blob/master/marketplace/pdx-deploy-from-marketplace.md)
   - [English](https://github.com/rexzj266/oracle-pgx-on-dbcs-quickstart/blob/master/marketplace/pdx-deploy-from-marketplace.md)
   - [中文版](https://github.com/rexzj266/oracle-pgx-on-dbcs-quickstart/blob/master/marketplace/pdx-deploy-from-marketplace-ch.md)
   - [日本語](https://github.com/kumasan368/oracle-pgx-on-dbcs-quickstart1/blob/master/marketplace/pdx-deploy-from-marketplace-jp.md)
-
-- [Create and populate the Online Retail tables](https://github.com/rexzj266/oracle-pgx-on-dbcs-quickstart/blob/master/create-and-populate-online-retail-tables/create-and-populate-online-retail-tables.md)


### PR DESCRIPTION
Temporally removed other tutorials (manual installation, online retail) which will not be updated for 21.1 first. Also, changed the title of the tutorial, to make it clearer that it is using DBCS (not ADB).